### PR TITLE
fixed warning with layout

### DIFF
--- a/PinCodeInputView.podspec
+++ b/PinCodeInputView.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "PinCodeInputView"
-  s.version      = "1.0.0"
+  s.version      = "1.0.1"
   s.summary      = "TextView for entering pin code. "
 
   s.description  = <<-DESC

--- a/PinCodeInputView/PinCodeInputView.swift
+++ b/PinCodeInputView/PinCodeInputView.swift
@@ -148,7 +148,12 @@ public class PinCodeInputView<T: UIView & ItemType>: UIControl, UITextInputTrait
         if autoResizes {
             self.appearance = ItemAppearance(itemSize: CGSize(width: (self.bounds.width - (self.itemSpacing * CGFloat(self.digit))) / CGFloat(self.digit), height: appearance.itemSize.height), font: appearance.font, textColor: appearance.textColor, backgroundColor: appearance.backgroundColor, cursorColor: appearance.cursorColor, cornerRadius: appearance.cornerRadius, borderColor: appearance.borderColor)
         }
-        items.forEach { $0.itemView.set(appearance: appearance) }
+        items.forEach {
+            $0.itemView.set(appearance: appearance)
+            $0.itemView.translatesAutoresizingMaskIntoConstraints = false
+            $0.itemView.widthAnchor.constraint(equalToConstant: appearance.itemSize.width).isActive = true
+            $0.itemView.heightAnchor.constraint(equalToConstant: appearance.itemSize.height).isActive = true
+        }
     }
     
     private func updateText() {

--- a/PinCodeInputView/PinCodeInputView.swift
+++ b/PinCodeInputView/PinCodeInputView.swift
@@ -30,10 +30,6 @@ public class PinCodeInputView<T: UIView & ItemType>: UIControl, UITextInputTrait
         return text.count == digit
     }
 
-    override public var intrinsicContentSize: CGSize {
-        return stackView.bounds.size
-    }
-
     private let digit: Int
     private let itemSpacing: CGFloat
     private var changeTextHandler: ((String) -> Void)? = nil
@@ -92,6 +88,8 @@ public class PinCodeInputView<T: UIView & ItemType>: UIControl, UITextInputTrait
         stackView.spacing = itemSpacing
         stackView.axis = .horizontal
         stackView.distribution = .fillEqually
+
+        self.makeConstraints()
     }
     
     private func setupTextField() {
@@ -120,21 +118,13 @@ public class PinCodeInputView<T: UIView & ItemType>: UIControl, UITextInputTrait
 
     // MARK: - Functions
 
-    override public func layoutSubviews() {
-        super.layoutSubviews()
-        
-        guard let appearance = appearance else {
-            stackView.frame = bounds
-            return
-        }
-        
-        stackView.bounds = CGRect(
-            x: 0,
-            y: 0,
-            width: (appearance.itemSize.width * CGFloat(digit)) + (itemSpacing * CGFloat(digit - 1)),
-            height: appearance.itemSize.height
-        )
-        stackView.center = CGPoint(x: bounds.width / 2, y: bounds.height / 2)
+    private func makeConstraints() {
+        self.stackView.translatesAutoresizingMaskIntoConstraints = false
+        self.stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+        self.stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
+        self.stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
+        self.stackView.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
+        self.setNeedsLayout()
     }
 
     public func set(text: String, shouldValidate: Bool = true) {


### PR DESCRIPTION
Fixed warning:
```
[LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x600000a281e0 'UISV-canvas-connection' UIStackView:0x7fe47388e1f0.leading == _TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe4712cfeb0.leading   (active)>",
    "<NSLayoutConstraint:0x600000a28230 'UISV-canvas-connection' H:[_TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe471067780]-(0)-|   (active, names: '|':UIStackView:0x7fe47388e1f0 )>",
    "<NSLayoutConstraint:0x600000a28320 'UISV-fill-equally' _TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe47104ca40.width == _TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe4712cfeb0.width   (active)>",
    "<NSLayoutConstraint:0x600000a283c0 'UISV-fill-equally' _TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe471064850.width == _TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe4712cfeb0.width   (active)>",
    "<NSLayoutConstraint:0x600000a28550 'UISV-fill-equally' _TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe471067780.width == _TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe4712cfeb0.width   (active)>",
    "<NSLayoutConstraint:0x600000a28280 'UISV-spacing' H:[_TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe4712cfeb0]-(10)-[_TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe47104ca40]   (active)>",
    "<NSLayoutConstraint:0x600000a28370 'UISV-spacing' H:[_TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe47104ca40]-(10)-[_TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe471064850]   (active)>",
    "<NSLayoutConstraint:0x600000a28410 'UISV-spacing' H:[_TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe471064850]-(10)-[_TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe471067780]   (active)>",
    "<NSLayoutConstraint:0x600000a280a0 'UIView-Encapsulated-Layout-Width' UIStackView:0x7fe47388e1f0.width == 0   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x600000a28410 'UISV-spacing' H:[_TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe471064850]-(10)-[_TtGCGC16PinCodeInputView16PinCodeInputViewC913MBPinItemView_P10$1104f599017ContainerItemViewS2__S2__:0x7fe471067780]   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
```